### PR TITLE
Add an LLVM CMake setting to narrow the installs.

### DIFF
--- a/BuildSettings.txt
+++ b/BuildSettings.txt
@@ -19,6 +19,10 @@
 # Set build type. This is a CMake built-in so we use its real type.
 set(CMAKE_BUILD_TYPE Release CACHE STRING "")
 
+# Only install the toolchain components of LLVM rather than all the libraries
+# and headers.
+set(LLVM_INSTALL_TOOLCHAIN_ONLY ON CACHE UNINITIALIZED "")
+
 # Select components to build 
 set(LLVM_ENABLE_PROJECTS
     clang


### PR DESCRIPTION
Because the GitHub actions happen to be *installing* the toolchain and
not just building it, we can use this to create significantly smaller
archives that will be faster to download and extract.